### PR TITLE
Fix error when API does not return result

### DIFF
--- a/agavepy/agave.py
+++ b/agavepy/agave.py
@@ -416,8 +416,8 @@ class Operation(object):
                     (self.operation == 'download'
                      or self.operation == 'downloadFromDefaultSystem')):
                 return resp
-            result = self.post_process(resp.json(),
-                                       self.return_type)['result']
+            processed = self.post_process(resp.json(), self.return_type)
+            result = processed['result'] if 'result' in processed else None
             # if operation is clients.create, save name
             if self.resource == 'clients' and self.operation == 'create':
                 save(result['name'],


### PR DESCRIPTION
There are times when the API does not return "result" in the response, e.g. `DELETE /meta/v2/data/{uuid}`. This allows for the result to be missing in the response and returns `None` instead.