### PR TITLE
Boolean parameters with value=False are skipped

### DIFF
--- a/agavepy/swaggerpy/client.py
+++ b/agavepy/swaggerpy/client.py
@@ -75,7 +75,7 @@ class Operation(object):
             # Turn list params into comma separated values
             if isinstance(value, list):
                 value = ",".join(value)
-            if value:
+            if value is not None:
                 param_type = param['paramType']
                 if param_type == 'path':
                     uri = uri.replace('{%s}' % pname, str(value))


### PR DESCRIPTION
I noticed when passing a parameter with a value=False the client returns an error that the parameter does not exist.