### PR TITLE
fix default/public/private parameters for systems list

### DIFF
--- a/agavepy/resources.json
+++ b/agavepy/resources.json
@@ -7461,15 +7461,7 @@
                                         "required": false,
                                         "type": "boolean",
                                         "paramType": "query",
-                                        "name": "publicOnly"
-                                    },
-                                    {
-                                        "description": "Should only private available systems be returned",
-                                        "allowMultiple": false,
-                                        "required": false,
-                                        "type": "boolean",
-                                        "paramType": "query",
-                                        "name": "privateOnly"
+                                        "name": "public"
                                     }
                                 ],
                                 "nickname": "list",

--- a/agavepy/resources.json.j2
+++ b/agavepy/resources.json.j2
@@ -7477,15 +7477,7 @@
                                         "required": false,
                                         "type": "boolean",
                                         "paramType": "query",
-                                        "name": "publicOnly"
-                                    },
-                                    {
-                                        "description": "Should only private available systems be returned",
-                                        "allowMultiple": false,
-                                        "required": false,
-                                        "type": "boolean",
-                                        "paramType": "query",
-                                        "name": "privateOnly"
+                                        "name": "public"
                                     }
                                 ],
                                 "nickname": "list",


### PR DESCRIPTION
The `privateOnly` parameter does not seem to exist, and `publicOnly` should be `public`. Setting `public=True` will return public systems, `public=False` returns private systems, and not specifying the parameter returns both.