### PR TITLE
Pass copyright to TACC and change to BSD license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,31 +5,41 @@ Swagger-py (in agavepy/swaggerpy) is copyright of Digium:
     Swagger.py is licensed with a BSD 3-Clause License.
 
 
-Agavepy is licensed under MIT License by Walter Moreira.
+Agavepy is licensed under BSD License by Texas Advanced Computing Center.
 
 ---
 
-The MIT License (MIT)
+Copyright (c) 2016, Texas Advanced Computing Center
+All rights reserved.
 
-Copyright (c) 2014 Walter Moreira
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+* Neither the name of the University of Texas at Austin nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the FreeBSD Project.
 
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Finally, a client can be generated directly from a JWT in order to bypass the AP
 License
 =======
 
-Agavepy is licensed under the MIT license.
+Agavepy is licensed under the BSD license.
 
 Swagger.py is copyright of Digium, Inc., and licensed under BSD 3-Clause License.
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_data={'agavepy': ['resources.json', 'resources.json.j2']},
     data_files=[('', ['requirements.txt'])],
     install_requires=requires,
-    license="MIT",
+    license="BSD",
     zip_safe=False,
     keywords='',
     classifiers=[


### PR DESCRIPTION
Copyright holder of agavepy should be TACC, and license should be BSD instead of MIT.  Changing accordingly.