### PR TITLE
Add `privileged` parameter to `listMetadata`

### DIFF
--- a/agavepy/resources.json.j2
+++ b/agavepy/resources.json.j2
@@ -4553,6 +4553,14 @@
                                         "type": "integer",
                                         "paramType": "query",
                                         "name": "offset"
+                                    },
+                                    {
+                                        "defaultValue": true,
+                                        "description": "If false, implicit permissions are ignored and only records to which the user has explicit permissions are returned",
+                                        "required": false,
+                                        "type": "boolean",
+                                        "paramType": "query",
+                                        "name": "privileged"
                                     }
                                 ],
                                 "type": "MultipleMetadataResponse",


### PR DESCRIPTION
See [AG-123](https://agaveapi.atlassian.net/projects/AH/queues/custom/5/AH-123) for more details/history.

If a user is a tenant admin then that user has implicit permissions on all metadata. This affects application features built on metadata and sharing for users with tenant admin role, since those users will always see everything, not just records they own or that other users have shared with them.

This additional query parameter was added and when set to `false`, implicit permissions are ignored and only records to which the user is owner or has an explicit permission set will be returned.