### PR TITLE
files.getHistory missing systemId parameter

### DIFF
--- a/agavepy/resources.json.j2
+++ b/agavepy/resources.json.j2
@@ -2621,6 +2621,14 @@
                             {
                                 "parameters": [
                                     {
+                                        "description": "The unique id of the system on which the data resides.",
+                                        "allowMultiple": false,
+                                        "required": true,
+                                        "type": "string",
+                                        "paramType": "path",
+                                        "name": "systemId"
+                                    },
+                                    {
                                         "description": "The path of the file relative to the given system root location.",
                                         "allowMultiple": false,
                                         "required": true,


### PR DESCRIPTION
The `systemId` parameter was missing, which made the `files.getHistory` call fail with the error:

```
TypeError: 'getHistory' does not have parameters ['systemId']
```

This adds the `systemId` parameter to the spec for `getHistory`.