### PR TITLE
Updating to 2.2.6 API

### DIFF
--- a/agavepy/resources.json.j2
+++ b/agavepy/resources.json.j2
@@ -491,7 +491,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/clients/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "clients"
         },
@@ -2143,7 +2143,7 @@
                     }
                 ],
                 "resourcePath": "/apps/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "apps"
         },
@@ -3193,7 +3193,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/files/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "files"
         },
@@ -4514,7 +4514,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/jobs/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "jobs"
         },
@@ -6004,7 +6004,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/meta/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "meta"
         },
@@ -6733,7 +6733,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/monitors/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "monitors"
         },
@@ -7161,7 +7161,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/notifications/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "notifications"
         },
@@ -7421,7 +7421,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/postits/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "postits"
         },
@@ -7962,7 +7962,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/profiles/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "profiles"
         },
@@ -9668,7 +9668,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/systems/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "systems"
         },
@@ -10001,7 +10001,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/transforms/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "transforms"
         },
@@ -11068,7 +11068,7 @@
                 },
                 "basePath": "https://{{ api_server_base }}",
                 "resourcePath": "/actors/v2",
-                "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+                "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "actors"
         },
@@ -12460,7 +12460,7 @@
             },
             "basePath": "https://{{ api_server_base }}",
             "resourcePath": "/admin/v2",
-            "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+            "apiVersion": "2.2.6-r4f1bf09"
             },
             "name": "admin"
         }
@@ -12470,5 +12470,5 @@
     "produces": [
         "application/json"
     ],
-    "apiVersion": "2.0.0-SNAPSHOT-r1dc40"
+    "apiVersion": "2.2.6-r4f1bf09"
 }


### PR DESCRIPTION
We're not running against 2.0.0-SNAPSHOT.