### PR TITLE
Fix utf8 encoding error when opening resource_exceptions.json

### DIFF
--- a/agavepy/agave.py
+++ b/agavepy/agave.py
@@ -268,7 +268,7 @@ class Agave(object):
 
         if self.resources is None:
             self.resources = load_resource(self.api_server)
-        self.resource_exceptions = json.load(open(os.path.join(HERE, 'resource_exceptions.json'), 'r'))
+        self.resource_exceptions = json.load(open(os.path.join(HERE, 'resource_exceptions.json'), 'r', encoding='utf-8'))
         self.host = urllib.parse.urlsplit(self.api_server).netloc
         if self.token_callback and not hasattr(self.token_callback, '__call__'):
             raise AgaveError('token_callback must be callable.')


### PR DESCRIPTION
## Description                                                                  
Instantiating an `Agave` object throws an exception in python 3.6, point of failure being the `open`ing of the `resource_exceptions.json` file:
> ```UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 8993: ordinal not in range(128)```
<details>
<summary>Exception Traceback:</summary>
<p>

```bash
[root@frontera_prtl_django server]# ipython
Python 3.6.8 (default, Aug  7 2019, 17:28:10)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.8.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from agavepy.agave import Agave

In [2]: Agave()
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-2-0cfaa5d4a0cc> in <module>
----> 1 Agave()

/usr/local/lib/python3.6/site-packages/agavepy/agave.py in __init__(self, **kwargs)
    269         if self.resources is None:
    270             self.resources = load_resource(self.api_server)
--> 271         self.resource_exceptions = json.load(open(os.path.join(HERE, 'resource_exceptions.json'), 'r'))
    272         self.host = urllib.parse.urlsplit(self.api_server).netloc
    273         if self.token_callback and not hasattr(self.token_callback, '__call__'):

/usr/lib64/python3.6/json/__init__.py in load(fp, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    294
    295     """
--> 296     return loads(fp.read(),
    297         cls=cls, object_hook=object_hook,
    298         parse_float=parse_float, parse_int=parse_int,

/usr/lib64/python3.6/encodings/ascii.py in decode(self, input, final)
     24 class IncrementalDecoder(codecs.IncrementalDecoder):
     25     def decode(self, input, final=False):
---> 26         return codecs.ascii_decode(input, self.errors)[0]
     27
     28 class StreamWriter(Codec,codecs.StreamWriter):

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 8993: ordinal not in range(128)
```

</p>
</details>  

This can be fixed by opening the file with an `encoder='utf-8'` specified.

## Motivation and Context                                                       
<!--- Why is this change required? What problem does it solve? -->              
<!--- If it fixes an open issue, please link to the issue here. -->
Necessary in order to instantiate `Agave` objects via `from agavepy.agave import Agave`.
- [ ] I have raised an issue to propose this change (required)


## How Has This Been Tested?                                                    
<!--- Please describe in detail how you tested your changes. -->                
<!--- Include details of your testing environment, and the tests you ran to --> 
<!--- see how your change affects other areas of the code, etc. -->             
Tested with IPython 7.8.0 and Python 3.6.8 in a CentOS 7 docker container.
```
$ pip install git+https://github.com/rstijerina/agavepy
$ ipython
Python 3.6.8 (default, Aug  7 2019, 17:28:10)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.8.0 -- An enhanced Interactive Python. Type '?' for help.
In [1]: from agavepy.agave import Agave

In [2]: Agave()
Out[2]: <agavepy.agave.Agave at 0x7faef42e51d0>
```

## Types of changes                                                             
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)                        
- [ ] New feature (non-breaking change which adds functionality)                
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.                           
- [ ] My change requires a change to the documentation.                         
- [ ] I have updated the documentation accordingly.                             
- [ ] I have signed-off my commits with `git commit -s`                         
- [ ] I have added tests to cover my changes.                                   
- [ ] All new and existing tests passed.
