### PR TITLE
Remove attrdict dependency as it doesn't work for Python >3.9

### DIFF
--- a/agavepy/settings/__init__.py
+++ b/agavepy/settings/__init__.py
@@ -11,7 +11,7 @@ with warnings.catch_warnings():
         if not load_dotenv(find_dotenv(usecwd=True)):
             load_dotenv(os.path.join(os.path.expanduser('~'), '.env'))
 
-from attrdict import AttrDict  # noqa
+from ..util import AttrDict  # noqa
 from .helpers import ENV_PREFIX  # noqa
 from .log import *  # noqa
 from .tenancy import *  # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ petname>=2.6
 cloudpickle>=1.3.0
 requests_toolbelt>=0.9.1
 future>=0.18.2
-attrdict>=2.0.0
 requests>=2.23.0
 arrow>=0.15.5
 curlify>=2.2.1


### PR DESCRIPTION
## Description                                                                  
This PR uses a local custom version of AttrDict already defined in util instead of attrdict, which is deprecated and breaks for Python >3.9
                                                                                
## Motivation and Context                                                       
AgavePy can run on Python >3.9                                                                                
                                                                                
## How Has This Been Tested?                                                    
                                                                                
## Types of changes                                                             
- [x] Bug fix (non-breaking change which fixes an issue)  Fixes #125 
                                                                             
## Checklist:                                                                   
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.                           
- [ ] My change requires a change to the documentation.                         
- [ ] I have updated the documentation accordingly.                             
- [ ] I have signed-off my commits with `git commit -s`                         
- [ ] I have added tests to cover my changes.                                   
- [ ] All new and existing tests passed.
